### PR TITLE
Update allocation algorithm with leftover tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ python loan_allocator_gui.py
 
 Select the *Submission* and *Collected* Excel files. After processing, choose where to save `output.xlsx`. A summary of records processed and totals is displayed.
 
+If some payments cannot be matched to any outstanding instalment, the tool reports the unallocated balance in the summary.
+


### PR DESCRIPTION
## Summary
- handle per-payment allocation order in `allocate`
- track leftover amounts and include them in the results dataclass
- update GUI summary and progress display
- mention possible unallocated balances in the README

## Testing
- `python -m py_compile loan_allocator_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684d9523c59083299f555716b2292abf